### PR TITLE
Avoid calling colcon twice and passing CMake args to Acados

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,6 +49,24 @@ if(${BUILD_ACADOS_TEMPLATE})
       found in '${ACADOS_PYTHON_INTERFACE_PCK_DIR}' will be installed in \
       '${ACADOS_PYTHON_INTERFACE_PATH}'."
     )
+
+    set(TERA_RENDERER "${ACADOS_SOURCE_DIR}/bin/t_renderer")
+    if(NOT EXISTS "${TERA_RENDERER}")
+      message(STATUS "Downloading tera renderer")
+
+      set(TERA_VERSION "0.0.34")
+      if(UNIX AND NOT APPLE)
+        set(TERA_SUFFIX linux)
+      elseif(APPLE)
+        set(TERA_SUFFIX osx)
+      else()
+        set(TERA_SUFFIX windows)
+      endif()
+
+      file(DOWNLOAD "https://github.com/acados/tera_renderer/releases/download/v${TERA_VERSION}/t_renderer-v${TERA_VERSION}-${TERA_SUFFIX}" ${TERA_RENDERER})
+      file(CHMOD ${TERA_RENDERER} PERMISSIONS OWNER_READ OWNER_WRITE GROUP_READ GROUP_WRITE OWNER_EXECUTE GROUP_EXECUTE WORLD_READ WORLD_EXECUTE)
+    endif()
+
   else()
     # Force a CMAKE regeneration at next 'colcon build' call
     include("${CMAKE_CURRENT_LIST_DIR}/cmake/force_regenerate.cmake")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,15 @@ option(BUILD_ACADOS_TEMPLATE
   ON
 )
 
+# ACADOS options on External libs
+option(ACADOS_WITH_QPOASES "qpOASES solver" OFF)
+option(ACADOS_WITH_DAQP "DAQP solver" OFF)
+option(ACADOS_WITH_HPMPC "HPMPC solver" OFF)
+option(ACADOS_WITH_QORE "QORE solver" OFF)
+option(ACADOS_WITH_OOQP "OOQP solver" OFF)
+option(ACADOS_WITH_QPDUNES "qpDUNES solver" OFF)
+option(ACADOS_WITH_OSQP "OSQP solver" OFF)
+
 # Setup
 if(NOT CMAKE_CXX_STANDARD)
   set(CMAKE_CXX_STANDARD 17) # Default to C++17
@@ -28,7 +37,15 @@ ament_vendor(acados_vendor_ros2
   SATISFIED ${acados_FOUND}
   VCS_URL https://github.com/acados/acados.git
   VCS_VERSION v0.3.2
-)
+  CMAKE_ARGS
+"-DACADOS_WITH_QPOASES=${ACADOS_WITH_QPOASES};\
+-DACADOS_WITH_DAQP=${ACADOS_WITH_DAQP};\
+-DACADOS_WITH_HPMPC=${ACADOS_WITH_HPMPC};\
+-DACADOS_WITH_QORE=${ACADOS_WITH_QORE};\
+-DACADOS_WITH_OOQP=${ACADOS_WITH_OOQP};\
+-DACADOS_WITH_QPDUNES=${ACADOS_WITH_QPDUNES};\
+-DACADOS_WITH_OSQP=${ACADOS_WITH_OSQP}"
+  )
 ament_export_dependencies(acados)
 
 set(ACADOS_SOURCE_DIR ${CMAKE_INSTALL_PREFIX}/opt/acados_vendor_ros2) # lib + include

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,52 +33,53 @@ ament_export_dependencies(acados)
 
 set(ACADOS_SOURCE_DIR ${CMAKE_INSTALL_PREFIX}/opt/acados_vendor_ros2) # lib + include
 set(ACADOS_SOURCE_BUILD_DIR ${CMAKE_BINARY_DIR}/acados_vendor_ros2-prefix/src/acados_vendor_ros2) # Source files
+
+# Source files
 set(ACADOS_PYTHON_INTERFACE_PATH none) # Python package after install, set below if package built
 
 if(${BUILD_ACADOS_TEMPLATE})
   set(ACADOS_PYTHON_INTERFACE_PCK_DIR "${ACADOS_SOURCE_BUILD_DIR}/interfaces/acados_template/acados_template")
-  if(EXISTS "${ACADOS_PYTHON_INTERFACE_PCK_DIR}/__init__.py")
-    ament_python_install_package(
-      acados_template
-      PACKAGE_DIR ${ACADOS_PYTHON_INTERFACE_PCK_DIR}
-    )
-    set(ACADOS_PYTHON_INTERFACE_PATH ${CMAKE_INSTALL_PREFIX}/${PYTHON_INSTALL_DIR}/acados_template) # Python package after install
-    message(
-      STATUS
-      "The Python interface (acados_template) \
-      found in '${ACADOS_PYTHON_INTERFACE_PCK_DIR}' will be installed in \
-      '${ACADOS_PYTHON_INTERFACE_PATH}'."
-    )
 
-    set(TERA_RENDERER "${ACADOS_SOURCE_DIR}/bin/t_renderer")
-    if(NOT EXISTS "${TERA_RENDERER}")
-      message(STATUS "Downloading tera renderer")
+  if(NOT EXISTS "${ACADOS_PYTHON_INTERFACE_PCK_DIR}")
+     message(STATUS "Cloning Acados source")
+     file(MAKE_DIRECTORY ${ACADOS_SOURCE_BUILD_DIR})
+      execute_process(COMMAND git clone -c advice.detachedHead=false --quiet --recursive https://github.com/acados/acados.git -b v0.3.2 .
+                      WORKING_DIRECTORY ${ACADOS_SOURCE_BUILD_DIR}
+                      RESULT_VARIABLE ACADOS_GIT_OUT
+                      OUTPUT_VARIABLE ACADOS_GIT_OUT)
+  else()
+    message(STATUS "${ACADOS_SOURCE_BUILD_DIR} already exists")
+  endif()
 
-      set(TERA_VERSION "0.0.34")
-      if(UNIX AND NOT APPLE)
-        set(TERA_SUFFIX linux)
-      elseif(APPLE)
-        set(TERA_SUFFIX osx)
-      else()
-        set(TERA_SUFFIX windows)
-      endif()
+  ament_python_install_package(
+    acados_template
+    PACKAGE_DIR ${ACADOS_PYTHON_INTERFACE_PCK_DIR}
+  )
+  set(ACADOS_PYTHON_INTERFACE_PATH ${CMAKE_INSTALL_PREFIX}/${PYTHON_INSTALL_DIR}/acados_template) # Python package after install
+  message(
+    STATUS
+    "The Python interface (acados_template) \
+    found in '${ACADOS_PYTHON_INTERFACE_PCK_DIR}' will be installed in \
+    '${ACADOS_PYTHON_INTERFACE_PATH}'."
+  )
 
-      file(DOWNLOAD "https://github.com/acados/tera_renderer/releases/download/v${TERA_VERSION}/t_renderer-v${TERA_VERSION}-${TERA_SUFFIX}" ${TERA_RENDERER})
-      file(CHMOD ${TERA_RENDERER} PERMISSIONS OWNER_READ OWNER_WRITE GROUP_READ GROUP_WRITE OWNER_EXECUTE GROUP_EXECUTE WORLD_READ WORLD_EXECUTE)
+  set(TERA_RENDERER "${ACADOS_SOURCE_DIR}/bin/t_renderer")
+  if(NOT EXISTS "${TERA_RENDERER}")
+    # Add empty bin directory (used to download the tera renderer)
+    install(DIRECTORY DESTINATION "opt/${PROJECT_NAME}/bin")
+    message(STATUS "Downloading tera renderer")
+
+    set(TERA_VERSION "0.0.34")
+    if(UNIX AND NOT APPLE)
+      set(TERA_SUFFIX linux)
+    elseif(APPLE)
+      set(TERA_SUFFIX osx)
+    else()
+      set(TERA_SUFFIX windows)
     endif()
 
-  else()
-    # Force a CMAKE regeneration at next 'colcon build' call
-    include("${CMAKE_CURRENT_LIST_DIR}/cmake/force_regenerate.cmake")
-    force_regenerate_at_next_build()
-
-    message(
-      WARNING
-      "The Python interface (acados_template) could not be built \
-      because the external project was not yet downloaded!\n \
-      Please re-build the project once again.\n \
-      Note: if it doesn't work, please try with the cmake arg '-DBUILD_ACADOS_TEMPLATE=ON'!"
-    )
+    file(DOWNLOAD "https://github.com/acados/tera_renderer/releases/download/v${TERA_VERSION}/t_renderer-v${TERA_VERSION}-${TERA_SUFFIX}" ${TERA_RENDERER})
+    file(CHMOD ${TERA_RENDERER} PERMISSIONS OWNER_READ OWNER_WRITE GROUP_READ GROUP_WRITE OWNER_EXECUTE GROUP_EXECUTE WORLD_READ WORLD_EXECUTE)
   endif()
 endif()
 ament_environment_hooks("${CMAKE_CURRENT_SOURCE_DIR}/env-hooks/${PROJECT_NAME}.sh.in")
@@ -113,8 +114,5 @@ install(
   DESTINATION
     share/${PROJECT_NAME}/cmake/Modules
 )
-
-# Add empty bin directory (used to download the tera renderer)
-install(DIRECTORY DESTINATION "opt/${PROJECT_NAME}/bin")
 
 ament_package(CONFIG_EXTRAS acados_vendor_ros2-extras.cmake)


### PR DESCRIPTION
Hi,

Thanks for this package that I'll try to use for Acados-based MPC.

In this PR I propose 3 updates that might help distributing the package:

- pre-clone the acados git repo to make it available for Python install (avoids double call to colcon)
- download the Tera renderer from CMake. Indeed, if the package is installed system-wide then the user might not have the privilege to write in the expected folder 
- add CMake arguments to forward to Acados (e.g. what solvers to use)