### PR TITLE
set acados v0.3.6

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,7 @@
 cmake_minimum_required(VERSION 3.10)
 project(acados_vendor_ros2)
 
+set(ACADOS_VERSION "0.3.6")
 # CMake options
 option(FORCE_BUILD_VENDOR_PKG
   "Build Acados from source, even if system-installed package is available"
@@ -31,12 +32,12 @@ find_package(ament_cmake_python REQUIRED)
 find_package(ament_cmake_vendor_package REQUIRED)
 
 list(INSERT CMAKE_MODULE_PATH 0 "${CMAKE_CURRENT_SOURCE_DIR}/cmake/Modules")
-find_package(acados 0.3.2 EXACT QUIET)
+find_package(acados ${ACADOS_VERSION} EXACT QUIET)
 
 ament_vendor(acados_vendor_ros2
   SATISFIED ${acados_FOUND}
   VCS_URL https://github.com/acados/acados.git
-  VCS_VERSION v0.3.2
+  VCS_VERSION v${ACADOS_VERSION}
   CMAKE_ARGS
   "-DACADOS_WITH_QPOASES=${ACADOS_WITH_QPOASES};\
   -DACADOS_WITH_DAQP=${ACADOS_WITH_DAQP};\
@@ -60,7 +61,7 @@ if(${BUILD_ACADOS_TEMPLATE})
   if(NOT EXISTS "${ACADOS_PYTHON_INTERFACE_PCK_DIR}")
     message(STATUS "Cloning Acados source")
     file(MAKE_DIRECTORY ${ACADOS_SOURCE_BUILD_DIR})
-    execute_process(COMMAND git clone -c advice.detachedHead=false --quiet --recursive https://github.com/acados/acados.git -b v0.3.2 .
+    execute_process(COMMAND git clone -c advice.detachedHead=false --quiet --recursive https://github.com/acados/acados.git -b v${ACADOS_VERSION} .
                     WORKING_DIRECTORY ${ACADOS_SOURCE_BUILD_DIR}
                     RESULT_VARIABLE ACADOS_GIT_OUT
                     OUTPUT_VARIABLE ACADOS_GIT_OUT)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -120,18 +120,7 @@ endif()
 ament_environment_hooks("${CMAKE_CURRENT_SOURCE_DIR}/env-hooks/${PROJECT_NAME}.sh.in")
 
 if(BUILD_TESTING)
-  find_package(ament_lint_auto REQUIRED)
-  set(ament_cmake_copyright_FOUND TRUE)
-  set(ament_cmake_cpplint_FOUND TRUE)
-
-  file(GLOB_RECURSE AMENT_LINT_AUTO_FILE_EXCLUDE
-    # Exclude auto generated c-code and CMakeLists
-    ${CMAKE_CURRENT_SOURCE_DIR}/cmake/Modules/FindFortranLibs.cmake
-  )
-
-  ament_lint_auto_find_test_dependencies()
-
-  # TODO(tpoignonec): Extra unit tests ?
+  # TODO(anyone): Add unit tests ?
   # See https://github.com/ros2/libyaml_vendor/blob/rolling/CMakeLists.txt for an example
 endif()
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # acados_vendor_ros2
 Simple ros2 vendor for Acados.
 
-![version](https://img.shields.io/badge/version-0.3.2-blue)
+![version](https://img.shields.io/badge/version-0.3.6-blue)
 [![CI (humble)](https://github.com/ICube-Robotics/acados_vendor_ros2/actions/workflows/ci.yml/badge.svg)](https://github.com/ICube-Robotics/acados_vendor_ros2/actions/workflows/ci.yml)
 [![Build tests (jazzy)](../../actions/workflows/ci-jazzy.yaml/badge.svg?branch=main)](../../actions/workflows/ci-jazzy.yaml?query=branch:main)
 [![Build tests (rolling)](../../actions/workflows/ci-rolling.yaml/badge.svg?branch=main)](../../actions/workflows/ci-rolling.yaml?query=branch:main)

--- a/package.xml
+++ b/package.xml
@@ -4,7 +4,7 @@
   schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="2">
   <name>acados_vendor_ros2</name>
-  <version>0.3.2</version>
+  <version>0.3.6</version>
   <description>Vendored version of acados.</description>
   <maintainer email="thibault.poignonec@gmail.com">Thibault Poignonec</maintainer>
   <license>Apache License 2.0</license>  <!-- the contents of this package are Apache 2.0 -->


### PR DESCRIPTION
__Higlights:__
- bump acados version to `0.3.6`
- remove `ament_lint_auto` tests (conflicting with pre-commit)